### PR TITLE
fix: README.md: Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ microcontroller at server for the [SSCMA](https://github.com/Seeed-Studio/SSCMA)
 models.
 
 More information about the sscma_micro can be found at
-[here](https://github.com/Seeed-Studio/sscma_micro/blob/dev/docs/protocol/at_protocol.md)
+[here](https://github.com/Seeed-Studio/SSCMA-Micro/blob/dev/docs/protocol/at_protocol.md)
 
 ## Usage
 


### PR DESCRIPTION
Hopefully [this](https://github.com/Seeed-Studio/SSCMA-Micro/blob/dev/docs/protocol/at_protocol.md) is the correct link

Fix https://github.com/Seeed-Studio/python-sscma/issues/9